### PR TITLE
feat: Implement Experiment Insights Screen

### DIFF
--- a/frontend/src/components/CreateExperimentModal.tsx
+++ b/frontend/src/components/CreateExperimentModal.tsx
@@ -1,0 +1,267 @@
+import React, { useState } from "react";
+import {
+    Modal,
+    View,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    StyleSheet,
+    ScrollView,
+    Alert,
+} from "react-native";
+import { theme } from "../theme";
+
+interface Props {
+    visible: boolean;
+    onClose: () => void;
+    onSubmit: (data: {
+        hypothesis: string;
+        metric_name: string;
+        variants: { name: string; description: string }[];
+    }) => void;
+}
+
+export default function CreateExperimentModal({ visible, onClose, onSubmit }: Props) {
+    const [hypothesis, setHypothesis] = useState("");
+    const [metricName, setMetricName] = useState("");
+    const [variants, setVariants] = useState<{ name: string; description: string }[]>([
+        { name: "", description: "" },
+        { name: "", description: "" },
+    ]);
+
+    const handleAddVariant = () => {
+        setVariants([...variants, { name: "", description: "" }]);
+    };
+
+    const handleRemoveVariant = (index: number) => {
+        if (variants.length <= 2) {
+            Alert.alert("Minimum Variants", "You need at least 2 variants for an experiment.");
+            return;
+        }
+        setVariants(variants.filter((_, i) => i !== index));
+    };
+
+    const handleVariantChange = (index: number, field: "name" | "description", value: string) => {
+        const updated = [...variants];
+        updated[index][field] = value;
+        setVariants(updated);
+    };
+
+    const handleSubmit = () => {
+        if (!hypothesis.trim()) {
+            Alert.alert("Missing Hypothesis", "Please enter a hypothesis.");
+            return;
+        }
+        if (!metricName.trim()) {
+            Alert.alert("Missing Metric", "Please enter a metric name.");
+            return;
+        }
+        if (variants.some((v) => !v.name.trim())) {
+            Alert.alert("Missing Variant Names", "All variants must have names.");
+            return;
+        }
+
+        onSubmit({ hypothesis, metric_name: metricName, variants });
+
+        // Reset form
+        setHypothesis("");
+        setMetricName("");
+        setVariants([
+            { name: "", description: "" },
+            { name: "", description: "" },
+        ]);
+    };
+
+    return (
+        <Modal visible={visible} animationType="slide" transparent>
+            <View style={styles.overlay}>
+                <View style={styles.container}>
+                    <View style={styles.header}>
+                        <Text style={styles.title}>New Experiment</Text>
+                        <TouchableOpacity onPress={onClose}>
+                            <Text style={styles.closeButton}>×</Text>
+                        </TouchableOpacity>
+                    </View>
+
+                    <ScrollView style={styles.content}>
+                        <Text style={styles.label}>Hypothesis</Text>
+                        <TextInput
+                            style={styles.input}
+                            placeholder="e.g., More light leads to faster growth"
+                            value={hypothesis}
+                            onChangeText={setHypothesis}
+                            multiline
+                        />
+
+                        <Text style={styles.label}>Metric Name</Text>
+                        <TextInput
+                            style={styles.input}
+                            placeholder="e.g., growth_rate, leaf_count"
+                            value={metricName}
+                            onChangeText={setMetricName}
+                        />
+
+                        <View style={styles.sectionHeader}>
+                            <Text style={styles.label}>Variants</Text>
+                            <TouchableOpacity onPress={handleAddVariant}>
+                                <Text style={styles.addButton}>+ Add Variant</Text>
+                            </TouchableOpacity>
+                        </View>
+
+                        {variants.map((variant, index) => (
+                            <View key={index} style={styles.variantCard}>
+                                <View style={styles.variantHeader}>
+                                    <Text style={styles.variantLabel}>Variant {index + 1}</Text>
+                                    {variants.length > 2 && (
+                                        <TouchableOpacity onPress={() => handleRemoveVariant(index)}>
+                                            <Text style={styles.removeButton}>Remove</Text>
+                                        </TouchableOpacity>
+                                    )}
+                                </View>
+                                <TextInput
+                                    style={styles.input}
+                                    placeholder="Variant name"
+                                    value={variant.name}
+                                    onChangeText={(text) => handleVariantChange(index, "name", text)}
+                                />
+                                <TextInput
+                                    style={styles.input}
+                                    placeholder="Description (optional)"
+                                    value={variant.description}
+                                    onChangeText={(text) => handleVariantChange(index, "description", text)}
+                                    multiline
+                                />
+                            </View>
+                        ))}
+                    </ScrollView>
+
+                    <View style={styles.footer}>
+                        <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
+                            <Text style={styles.cancelButtonText}>Cancel</Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity style={styles.submitButton} onPress={handleSubmit}>
+                            <Text style={styles.submitButtonText}>Create</Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            </View>
+        </Modal>
+    );
+}
+
+const styles = StyleSheet.create({
+    overlay: {
+        flex: 1,
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    container: {
+        backgroundColor: theme.colors.background,
+        borderRadius: 12,
+        width: "90%",
+        maxHeight: "80%",
+        overflow: "hidden",
+    },
+    header: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        padding: 20,
+        borderBottomWidth: 1,
+        borderBottomColor: theme.colors.border,
+    },
+    title: {
+        fontSize: 20,
+        fontWeight: "bold",
+        color: theme.colors.text,
+    },
+    closeButton: {
+        fontSize: 32,
+        color: theme.colors.textSecondary,
+        lineHeight: 32,
+    },
+    content: {
+        padding: 20,
+    },
+    label: {
+        fontSize: 16,
+        fontWeight: "600",
+        color: theme.colors.text,
+        marginBottom: 8,
+        marginTop: 12,
+    },
+    input: {
+        borderWidth: 1,
+        borderColor: theme.colors.border,
+        borderRadius: 8,
+        padding: 12,
+        fontSize: 16,
+        color: theme.colors.text,
+        backgroundColor: theme.colors.background,
+    },
+    sectionHeader: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        marginTop: 12,
+    },
+    addButton: {
+        color: theme.colors.primary,
+        fontSize: 14,
+        fontWeight: "600",
+    },
+    variantCard: {
+        backgroundColor: theme.colors.surface,
+        padding: 12,
+        borderRadius: 8,
+        marginTop: 12,
+    },
+    variantHeader: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        marginBottom: 8,
+    },
+    variantLabel: {
+        fontSize: 14,
+        fontWeight: "600",
+        color: theme.colors.text,
+    },
+    removeButton: {
+        color: theme.colors.error,
+        fontSize: 14,
+    },
+    footer: {
+        flexDirection: "row",
+        padding: 20,
+        borderTopWidth: 1,
+        borderTopColor: theme.colors.border,
+        gap: 12,
+    },
+    cancelButton: {
+        flex: 1,
+        padding: 12,
+        borderRadius: 8,
+        borderWidth: 1,
+        borderColor: theme.colors.border,
+        alignItems: "center",
+    },
+    cancelButtonText: {
+        color: theme.colors.text,
+        fontSize: 16,
+        fontWeight: "600",
+    },
+    submitButton: {
+        flex: 1,
+        padding: 12,
+        borderRadius: 8,
+        backgroundColor: theme.colors.primary,
+        alignItems: "center",
+    },
+    submitButtonText: {
+        color: "#fff",
+        fontSize: 16,
+        fontWeight: "600",
+    },
+});

--- a/frontend/src/screens/ExperimentsScreen.tsx
+++ b/frontend/src/screens/ExperimentsScreen.tsx
@@ -1,36 +1,149 @@
 import { useEffect, useState } from "react";
-import { FlatList, StyleSheet, Text, View } from "react-native";
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
 
 import { api } from "@/api/client";
+import { Experiment } from "@/types/plants";
+import CreateExperimentModal from "@/components/CreateExperimentModal";
+import { theme } from "@/theme";
 
 export function ExperimentsScreen() {
-  const [experiments, setExperiments] = useState<any[]>([]);
+  const [experiments, setExperiments] = useState<Experiment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [simulatingId, setSimulatingId] = useState<string | null>(null);
 
-  useEffect(() => {
+  const loadExperiments = () => {
+    setLoading(true);
     api.experiments
       .list()
-      .then(setExperiments)
-      .catch(() => setExperiments([]));
+      .then((data) => setExperiments(data as Experiment[]))
+      .catch(() => setExperiments([]))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadExperiments();
   }, []);
+
+  const handleCreateExperiment = async (data: {
+    hypothesis: string;
+    metric_name: string;
+    variants: { name: string; description: string }[];
+  }) => {
+    try {
+      await api.experiments.create(data);
+      setModalVisible(false);
+      loadExperiments();
+      Alert.alert("Success", "Experiment created successfully!");
+    } catch (error) {
+      Alert.alert("Error", "Failed to create experiment.");
+      console.error(error);
+    }
+  };
+
+  const handleSimulate = async (experimentId: string) => {
+    setSimulatingId(experimentId);
+    try {
+      await api.experiments.simulate(experimentId);
+      loadExperiments();
+      Alert.alert("Success", "Simulation completed!");
+    } catch (error) {
+      Alert.alert("Error", "Failed to run simulation.");
+      console.error(error);
+    } finally {
+      setSimulatingId(null);
+    }
+  };
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Experiment Studio</Text>
-      <FlatList
-        data={experiments}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={styles.card}>
-            <Text style={styles.cardTitle}>{item.name}</Text>
-            <Text style={styles.cardSubtitle}>{item.hypothesis}</Text>
-            <Text style={styles.metric}>{item.metric_keys?.join(", ")}</Text>
-          </View>
-        )}
-        ListEmptyComponent={
-          <Text style={styles.empty}>
-            Create variants from the backend dashboard to see them here.
-          </Text>
-        }
+      <View style={styles.header}>
+        <Text style={styles.title}>Experiment Studio</Text>
+        <TouchableOpacity
+          style={styles.createButton}
+          onPress={() => setModalVisible(true)}
+        >
+          <Text style={styles.createButtonText}>+ New</Text>
+        </TouchableOpacity>
+      </View>
+
+      {loading ? (
+        <ActivityIndicator size="large" color={theme.colors.primary} style={styles.loader} />
+      ) : (
+        <FlatList
+          data={experiments}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <View style={styles.card}>
+              <View style={styles.cardHeader}>
+                <Text style={styles.cardTitle}>{item.hypothesis}</Text>
+                <View style={styles.badge}>
+                  <Text style={styles.badgeText}>{item.status}</Text>
+                </View>
+              </View>
+
+              <Text style={styles.metricLabel}>
+                Metric: <Text style={styles.metricValue}>{item.metric_name}</Text>
+              </Text>
+
+              <View style={styles.variantsContainer}>
+                <Text style={styles.variantsTitle}>Variants:</Text>
+                {item.variants.map((variant) => (
+                  <View key={variant.id} style={styles.variantRow}>
+                    <View style={styles.variantInfo}>
+                      <Text style={styles.variantName}>{variant.name}</Text>
+                      {variant.description && (
+                        <Text style={styles.variantDesc}>{variant.description}</Text>
+                      )}
+                    </View>
+                    <View style={styles.metricContainer}>
+                      <Text style={styles.metricScore}>
+                        {variant.metric.toFixed(2)}
+                      </Text>
+                    </View>
+                  </View>
+                ))}
+              </View>
+
+              <TouchableOpacity
+                style={[
+                  styles.simulateButton,
+                  simulatingId === item.id && styles.simulateButtonDisabled,
+                ]}
+                onPress={() => handleSimulate(item.id)}
+                disabled={simulatingId === item.id}
+              >
+                {simulatingId === item.id ? (
+                  <ActivityIndicator size="small" color="#fff" />
+                ) : (
+                  <Text style={styles.simulateButtonText}>Run Simulation</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          )}
+          ListEmptyComponent={
+            <View style={styles.emptyContainer}>
+              <Text style={styles.emptyText}>No experiments yet</Text>
+              <Text style={styles.emptySubtext}>
+                Create your first experiment to get started
+              </Text>
+            </View>
+          }
+        />
+      )}
+
+      <CreateExperimentModal
+        visible={modalVisible}
+        onClose={() => setModalVisible(false)}
+        onSubmit={handleCreateExperiment}
       />
     </View>
   );
@@ -39,35 +152,153 @@ export function ExperimentsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
   },
   title: {
     fontSize: 22,
     fontWeight: "700",
-    marginBottom: 12,
+    color: theme.colors.text,
+  },
+  createButton: {
+    backgroundColor: theme.colors.primary,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  createButtonText: {
+    color: "#fff",
+    fontWeight: "600",
+    fontSize: 16,
+  },
+  loader: {
+    marginTop: 40,
   },
   card: {
     padding: 16,
+    marginHorizontal: 16,
+    marginVertical: 8,
     borderRadius: 12,
-    backgroundColor: "#fff",
+    backgroundColor: theme.colors.surface,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
     marginBottom: 12,
-    gap: 4,
   },
   cardTitle: {
     fontSize: 16,
     fontWeight: "600",
+    color: theme.colors.text,
+    flex: 1,
+    marginRight: 8,
   },
-  cardSubtitle: {
-    fontSize: 14,
-    color: "#6B7280",
+  badge: {
+    backgroundColor: theme.colors.primary,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 4,
   },
-  metric: {
+  badgeText: {
+    color: "#fff",
     fontSize: 12,
-    color: "#10B981",
+    fontWeight: "600",
   },
-  empty: {
+  metricLabel: {
+    fontSize: 14,
+    color: theme.colors.textSecondary,
+    marginBottom: 12,
+  },
+  metricValue: {
+    fontWeight: "600",
+    color: theme.colors.text,
+  },
+  variantsContainer: {
+    marginTop: 8,
+    marginBottom: 12,
+  },
+  variantsTitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: theme.colors.text,
+    marginBottom: 8,
+  },
+  variantRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: theme.colors.background,
+    borderRadius: 8,
+    marginBottom: 6,
+  },
+  variantInfo: {
+    flex: 1,
+  },
+  variantName: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: theme.colors.text,
+  },
+  variantDesc: {
+    fontSize: 12,
+    color: theme.colors.textSecondary,
+    marginTop: 2,
+  },
+  metricContainer: {
+    backgroundColor: theme.colors.secondary,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  metricScore: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#fff",
+  },
+  simulateButton: {
+    backgroundColor: theme.colors.secondary,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  simulateButtonDisabled: {
+    opacity: 0.6,
+  },
+  simulateButtonText: {
+    color: "#fff",
+    fontWeight: "600",
+    fontSize: 16,
+  },
+  emptyContainer: {
+    alignItems: "center",
+    marginTop: 60,
+    paddingHorizontal: 40,
+  },
+  emptyText: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: theme.colors.text,
+    marginBottom: 8,
+  },
+  emptySubtext: {
+    fontSize: 14,
+    color: theme.colors.textSecondary,
     textAlign: "center",
-    color: "#6B7280",
-    marginTop: 32,
   },
 });

--- a/frontend/src/types/plants.ts
+++ b/frontend/src/types/plants.ts
@@ -35,3 +35,19 @@ export type ScheduleDay = {
   date: string;
   tasks: CareTask[];
 };
+
+export type ExperimentVariant = {
+  id: string;
+  name: string;
+  description: string;
+  metric: number;
+};
+
+export type Experiment = {
+  id: string;
+  hypothesis: string;
+  metric_name: string;
+  variants: ExperimentVariant[];
+  created_at: string;
+  status: string;
+};


### PR DESCRIPTION
This PR implements the Experiment Insights Screen for Phase 2.4.

### Changes
- **Frontend**:
    - Added `CreateExperimentModal.tsx` for creating new experiments.
    - Updated `ExperimentsScreen.tsx` with full experiment management, including creation, listing, and simulation.
    - Added `Experiment` and `ExperimentVariant` type definitions.

### Features
- Create experiments with hypothesis, metric name, and variants.
- Display experiments with variant metrics.
- Run AI simulations to predict experiment outcomes.

### Verification
- Manual verification required on device/simulator.
- Backend requires API keys for simulation.

Closes #14